### PR TITLE
Add mean reversion strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The bot has been designed with error handling mechanisms for common issues such 
 4. **Latency Optimization**: Improving multi-threading and reducing the latency of API calls to minimize execution risk.
 5. **Order Book Analysis**: Implementing real-time order book analysis to ensure that liquidity constraints are dynamically managed.
 6. **Momentum Strategy**: Added a simple moving-average crossover strategy that can be enabled for bullish market regimes.
+7. **Mean Reversion Strategy**: Introduces a basic mean-reversion approach for bearish market conditions.
 
 ## Risks & Limitations
 

--- a/config.yaml
+++ b/config.yaml
@@ -46,7 +46,7 @@ strategy_manager:
   regime_mapping:
     default: "ScalpingStrategy"
     bullish: "MomentumStrategy"
-  #   bearish: "MeanReversionStrategy"
+    bearish: "MeanReversionStrategy"
 
 # --- Parameters specifically for the Scalping Strategy ---
 scalping_strategy:
@@ -60,6 +60,10 @@ scalping_strategy:
 momentum_strategy:
   short_window: 10
   long_window: 30
+
+mean_reversion_strategy:
+  window_size: 20
+  std_dev_threshold: 1.5
 
 # --- Optional: Model Inference ---
 # Set paths if you have trained models you want to load

--- a/hydrobot/config/settings.py
+++ b/hydrobot/config/settings.py
@@ -66,6 +66,15 @@ class MomentumStrategySettings(BaseModel):
     short_window: int = Field(10, description="Short moving average window size.")
     long_window: int = Field(30, description="Long moving average window size.")
 
+# --- Mean Reversion Strategy Settings ---
+class MeanReversionStrategySettings(BaseModel):
+    """Parameters for a basic mean reversion strategy."""
+    window_size: int = Field(20, description="Rolling window size for mean calculation.")
+    std_dev_threshold: float = Field(
+        1.5,
+        description="Standard deviation multiplier for entry/exit thresholds.",
+    )
+
 # --- Strategy Manager Settings ---
 class StrategyManagerSettings(BaseModel):
     """Settings for how strategies are selected and managed."""
@@ -103,6 +112,9 @@ class AppSettings(BaseModel):
     strategy_manager: StrategyManagerSettings = Field(default_factory=StrategyManagerSettings)
     scalping_strategy: ScalpingStrategySettings = Field(default_factory=ScalpingStrategySettings)
     momentum_strategy: MomentumStrategySettings = Field(default_factory=MomentumStrategySettings)
+    mean_reversion_strategy: MeanReversionStrategySettings = Field(
+        default_factory=MeanReversionStrategySettings
+    )
     model_inference: Optional[ModelInferenceSettings] = Field(default_factory=ModelInferenceSettings) # Optional for now
     redis: RedisSettings = Field(default_factory=RedisSettings)
 

--- a/hydrobot/strategies/__init__.py
+++ b/hydrobot/strategies/__init__.py
@@ -3,6 +3,7 @@
 from .base_strategy import Strategy, Signal
 from .impl_scalping import ScalpingStrategy
 from .impl_momentum import MomentumStrategy
+from .impl_mean_reversion import MeanReversionStrategy
 from .strategy_manager import StrategyManager
 
 __all__ = [
@@ -10,5 +11,6 @@ __all__ = [
     "Signal",
     "ScalpingStrategy",
     "MomentumStrategy",
+    "MeanReversionStrategy",
     "StrategyManager",
 ]

--- a/hydrobot/strategies/impl_mean_reversion.py
+++ b/hydrobot/strategies/impl_mean_reversion.py
@@ -1,0 +1,64 @@
+"""Simple mean reversion strategy using rolling mean and standard deviation."""
+
+from collections import deque
+from typing import Deque, Dict, Any, Optional
+
+from .base_strategy import Strategy, Signal
+from ..config.settings import AppSettings
+from ..utils.logger_setup import get_logger
+
+log = get_logger()
+
+
+class MeanReversionStrategy(Strategy):
+    """Mean reversion strategy based on z-score of recent prices."""
+
+    def __init__(self, strategy_config: Dict[str, Any], global_config: AppSettings):
+        super().__init__(strategy_config, global_config)
+        self.window_size = int(strategy_config.get("window_size", 20))
+        self.std_dev_threshold = float(strategy_config.get("std_dev_threshold", 1.5))
+        self.prices: Deque[float] = deque(maxlen=self.window_size)
+        log.info(
+            f"MeanReversion strategy initialized: window_size={self.window_size}, "
+            f"std_dev_threshold={self.std_dev_threshold}"
+        )
+
+    def on_market_update(self, market_data: Dict[str, Any]):
+        price = market_data.get("last_trade")
+        if price is not None:
+            self.prices.append(float(price))
+
+    def _calculate_stats(self) -> Optional[tuple[float, float]]:
+        if len(self.prices) < self.window_size:
+            return None
+        mean = sum(self.prices) / len(self.prices)
+        variance = sum((p - mean) ** 2 for p in self.prices) / len(self.prices)
+        std = variance ** 0.5
+        return mean, std
+
+    def generate_signal(
+        self,
+        market_data: Dict[str, Any],
+        model_prediction: Optional[Any] = None,
+    ) -> Signal:
+        signal = Signal(symbol=self.symbol, strategy_name=self.strategy_name)
+        stats = self._calculate_stats()
+        if stats is None:
+            log.debug(f"[{self.symbol}] Not enough data for mean calculation")
+            return signal
+        mean, std = stats
+        price = float(market_data.get("last_trade"))
+        upper = mean + self.std_dev_threshold * std
+        lower = mean - self.std_dev_threshold * std
+        log.debug(
+            f"[{self.symbol}] price={price:.4f}, mean={mean:.4f}, std={std:.4f}, upper={upper:.4f}, lower={lower:.4f}"
+        )
+        if price > upper:
+            signal.action = "SELL"
+            signal.price = market_data.get("bids", [[price]])[0][0]
+            signal.quantity = self.global_config.trading.default_trade_amount_usd / signal.price
+        elif price < lower:
+            signal.action = "BUY"
+            signal.price = market_data.get("asks", [[price]])[0][0]
+            signal.quantity = self.global_config.trading.default_trade_amount_usd / signal.price
+        return signal

--- a/hydrobot/strategies/strategy_manager.py
+++ b/hydrobot/strategies/strategy_manager.py
@@ -11,7 +11,7 @@ from typing import Dict, Type, Optional, Any
 from .base_strategy import Strategy
 from .impl_scalping import ScalpingStrategy
 from .impl_momentum import MomentumStrategy
-# from .impl_mean_reversion import MeanReversionStrategy
+from .impl_mean_reversion import MeanReversionStrategy
 
 from ..config.settings import get_config, AppSettings, StrategyManagerSettings
 from ..utils.logger_setup import get_logger
@@ -58,6 +58,9 @@ class StrategyManager:
         if "MomentumStrategy" not in strategies and MomentumStrategy:
              strategies["MomentumStrategy"] = MomentumStrategy
              log.debug("Explicitly added MomentumStrategy.")
+        if "MeanReversionStrategy" not in strategies and MeanReversionStrategy:
+             strategies["MeanReversionStrategy"] = MeanReversionStrategy
+             log.debug("Explicitly added MeanReversionStrategy.")
 
         if not strategies:
              log.warning("No strategy classes were automatically discovered!")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,8 +5,10 @@ from hydrobot.data_ingestion.market_data_stream import OrderBook
 from hydrobot.trading.position_manager import Position, PositionManager
 from hydrobot.strategies.base_strategy import Signal
 from hydrobot.strategies.impl_momentum import MomentumStrategy
+from hydrobot.strategies.impl_mean_reversion import MeanReversionStrategy
 from hydrobot.config.settings import (
     MomentumStrategySettings,
+    MeanReversionStrategySettings,
     AppSettings,
     ExchangeAPISettings,
     TradingSettings,
@@ -154,6 +156,27 @@ def test_momentum_strategy_signal_generation():
     strategy.on_market_update({"last_trade": 100.0})
     strategy.on_market_update({"last_trade": 101.0})
     strategy.on_market_update({"last_trade": 102.0})
+
+    data = {"last_trade": 103.0, "asks": [[103.0, 1.0]], "bids": [[102.0, 1.0]]}
+    signal = strategy.generate_signal(data)
+    assert signal.action in ["BUY", "SELL", "HOLD"]
+
+
+def test_mean_reversion_strategy_signal_generation():
+    """Ensure MeanReversionStrategy reacts to price extremes."""
+    global_config = AppSettings(
+        exchange=ExchangeAPISettings(name="binanceus"),
+        trading=TradingSettings(symbols=["BTC/USDT"], default_trade_amount_usd=10.0),
+    )
+    strategy = MeanReversionStrategy(
+        MeanReversionStrategySettings(window_size=3, std_dev_threshold=0.5),
+        global_config,
+    )
+    strategy.set_symbol("BTC/USDT")
+
+    strategy.on_market_update({"last_trade": 100.0})
+    strategy.on_market_update({"last_trade": 102.0})
+    strategy.on_market_update({"last_trade": 101.0})
 
     data = {"last_trade": 103.0, "asks": [[103.0, 1.0]], "bids": [[102.0, 1.0]]}
     signal = strategy.generate_signal(data)


### PR DESCRIPTION
## Summary
- implement `MeanReversionStrategy`
- expose new strategy in configuration and strategy manager
- support mean reversion settings in `AppSettings`
- document the new strategy in README
- add unit test coverage for the strategy

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*