### PR TITLE
Add tests and docs for pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ Avg Trade Duration:     1.00 minutes
 Total Return:           18.16%
 ```
 
+### Running Tests
+
+Unit tests are provided in the `tests/` directory. After installing the
+development dependencies, run the test suite with `pytest`:
+
+```bash
+pytest
+```
+
+For Poetry users you can also execute `poetry run pytest` which will use the
+virtual environment managed by Poetry.
+
 ### Running the Bot in Live Mode
 
 To run the bot live in real markets, use the following command:

--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -1,0 +1,38 @@
+import builtins
+import importlib
+import types
+
+import hydrobot.trading.trading_utils as utils
+
+
+def setup_module():
+    # Inject minimal market data into cache
+    utils._market_cache.clear()
+    utils._market_cache.update({
+        "BTC/USDT": {
+            "precision": {"amount": 4, "price": 2},
+            "limits": {"amount": {"min": 0.001}, "cost": {"min": 10}}
+        }
+    })
+
+
+def test_format_quantity_precision():
+    qty = utils.format_quantity("BTC/USDT", 1.234567)
+    assert abs(qty - 1.2345) < 1e-9
+
+
+def test_format_price_precision():
+    price = utils.format_price("BTC/USDT", 123.456)
+    assert abs(price - 123.46) < 1e-9
+
+
+def test_check_min_order_size_true():
+    assert utils.check_min_order_size("BTC/USDT", 0.01, 1000.0)
+
+
+def test_check_min_order_size_false_amount():
+    assert not utils.check_min_order_size("BTC/USDT", 0.0001, 1000.0)
+
+
+def test_check_min_order_size_false_cost():
+    assert not utils.check_min_order_size("BTC/USDT", 0.005, 100.0)


### PR DESCRIPTION
## Summary
- document how to run unit tests with pytest in README
- add unit tests for trading_utils helpers

## Testing
- `pytest -q` *(fails: command not found)*