### PR TITLE
Fix Signal dataclass and PositionManager methods

### DIFF
--- a/hydrobot/trading/position_manager.py
+++ b/hydrobot/trading/position_manager.py
@@ -4,7 +4,7 @@ import json
 import time
 import math # For isnan
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING, Any
 try:
     import redis  # type: ignore
 except ImportError:  # pragma: no cover
@@ -27,6 +27,9 @@ class Position:
     current_price: float = 0.0  # Added for test compatibility
     quantity: float = 0.0  # Keep for backward compatibility
     average_entry_price: float = 0.0  # Keep for backward compatibility
+    realized_pnl: float = 0.0
+    unrealized_pnl: float = 0.0
+    total_pnl: float = 0.0
     last_update_time: float = 0.0
 
     def update_position(self, fill_quantity: float, fill_price: float, timestamp: float):
@@ -85,28 +88,91 @@ class Position:
 
 class PositionManager:
     """Manages and tracks all open positions across different symbols."""
-    def __init__(self, config: 'AppSettings'):
+
+    def __init__(self, config: "AppSettings | Dict[str, Any]"):
         """Initializes the PositionManager."""
         self.config = config
         self.positions: Dict[str, Position] = {}
         self.redis_client: Optional[redis.Redis] = None
-        self.redis_key_prefix = f"{config.app_name or 'hydrobot'}:position:"  # Use default if app_name missing
+        app_name = config.get("app_name") if isinstance(config, dict) else getattr(config, "app_name", None)
+        self.redis_key_prefix = f"{app_name or 'hydrobot'}:position:"
         self._connect_redis()
         if self.redis_client:
             self._load_positions_from_redis()
         log.info("PositionManager initialized.")
-        # ... (rest of PositionManager methods remain the same) ...
+
+    def initialize_symbol(self, symbol: str) -> None:
+        """Ensure a symbol entry exists."""
+        if symbol not in self.positions:
+            self.positions[symbol] = Position(symbol=symbol)
+
+    def update_position(self, symbol: str, trade: Dict[str, Any], mark_price: float) -> Position:
+        """Update position based on a trade and return updated position."""
+        self.initialize_symbol(symbol)
+        position = self.positions[symbol]
+
+        side = trade.get("side", "").lower()
+        size = float(trade.get("size", 0))
+        price = float(trade.get("price", 0))
+        ts = trade.get("timestamp")
+        timestamp = ts.timestamp() if hasattr(ts, "timestamp") else float(ts)
+
+        if side == "buy":
+            new_size = position.size + size
+            position.entry_price = (
+                (position.size * position.entry_price + size * price) / new_size
+            ) if new_size != 0 else 0.0
+            position.size = new_size
+        elif side == "sell":
+            close_size = min(size, position.size)
+            position.realized_pnl += (price - position.entry_price) * close_size
+            position.size -= close_size
+            if position.size == 0:
+                position.entry_price = 0.0
+
+        position.quantity = position.size
+        position.average_entry_price = position.entry_price
+        position.unrealized_pnl = (
+            (mark_price - position.entry_price) * position.size if position.size != 0 else 0.0
+        )
+        position.total_pnl = position.realized_pnl + position.unrealized_pnl
+        position.last_update_time = timestamp
+
+        if self.redis_client:
+            self._save_position_to_redis(position)
+        return position
 
     def _connect_redis(self):
-        """Establishes connection to the Redis server."""
-        if self.config.redis and redis is not None:
+        """Establishes connection to the Redis server if configuration is provided."""
+        redis_cfg = None
+        if isinstance(self.config, dict):
+            redis_cfg = self.config.get("redis")
+        else:
+            redis_cfg = getattr(self.config, "redis", None)
+
+        if redis_cfg and redis is not None:
             try:
+                host = redis_cfg.get("host") if isinstance(redis_cfg, dict) else redis_cfg.host
+                port = redis_cfg.get("port", 6379) if isinstance(redis_cfg, dict) else redis_cfg.port
+                db = redis_cfg.get("db", 0) if isinstance(redis_cfg, dict) else redis_cfg.db
+                password = None
+                if isinstance(redis_cfg, dict):
+                    password = redis_cfg.get("password")
+                else:
+                    if getattr(redis_cfg, "password", None):
+                        password = redis_cfg.password.get_secret_value()
+
                 self.redis_client = redis.Redis(
-                    host=self.config.redis.host, port=self.config.redis.port, db=self.config.redis.db,
-                    password=self.config.redis.password.get_secret_value() if self.config.redis.password else None,
-                    decode_responses=True, socket_timeout=5, socket_connect_timeout=5 )
+                    host=host,
+                    port=port,
+                    db=db,
+                    password=password,
+                    decode_responses=True,
+                    socket_timeout=5,
+                    socket_connect_timeout=5,
+                )
                 self.redis_client.ping()
-                log.info(f"Successfully connected to Redis: {self.config.redis.host}:{self.config.redis.port}")
+                log.info(f"Successfully connected to Redis: {host}:{port}")
             except redis.exceptions.ConnectionError as e:
                 log.error(f"Redis connection failed: {e}.", exc_info=False)
                 self.redis_client = None
@@ -114,9 +180,9 @@ class PositionManager:
                 log.exception(f"Unexpected error during Redis connection: {e}")
                 self.redis_client = None
         else:
-             self.redis_client = None
-             if redis is None:
-                 log.warning("Redis package not installed. Persistence disabled.")
+            self.redis_client = None
+            if redis is None:
+                log.warning("Redis package not installed. Persistence disabled.")
 
     def _save_position_to_redis(self, position: Position):
         """Saves a single position object to Redis."""


### PR DESCRIPTION
## Summary
- extend `Signal` dataclass with extra fields used in tests
- add backwards compatibility handling in `Signal.__post_init__`
- implement basic position management helpers
- allow `PositionManager` to work with simple dictionaries and connect to Redis when available

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*