### PR TITLE
Fix test syntax issue and run tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -94,7 +94,8 @@ async def test_position_manager():
     # Test initial position update (buy)
     symbol = "BTC/USDT"
     quantity = 0.1  # Buy quantity
-    price = 100.0    timestamp = datetime.utcnow().timestamp()
+    price = 100.0
+    timestamp = datetime.utcnow().timestamp()
     manager.update_position_on_fill(symbol, quantity, price, timestamp)
     position = manager.get_position(symbol)
     assert position.symbol == "BTC/USDT"


### PR DESCRIPTION
## Summary
- fix syntax error in `test_core.py`
- run the available tests

## Testing
- `PYTHONPATH=venv/Lib/site-packages python3 -m pytest -q tests` *(fails: AttributeError: module 'cryptography.hazmat.bindings._rust.openssl' has no attribute 'hashes')*