### PR TITLE
Fix cryptography import issue

### DIFF
--- a/hydrobot/trading/trading_utils.py
+++ b/hydrobot/trading/trading_utils.py
@@ -2,8 +2,10 @@
 
 import math
 from decimal import Decimal, ROUND_DOWN, ROUND_UP # Use Decimal for precision
-import ccxt.async_support as ccxt # Needed for type hinting and accessing market info
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - avoid runtime dependency during tests
+    import ccxt.async_support as ccxt
 
 # --- FIX: Use relative import ---
 from ..utils.logger_setup import get_logger
@@ -12,9 +14,11 @@ log = get_logger()
 
 _market_cache: Dict[str, Dict[str, Any]] = {}
 
-async def update_market_cache(exchange: ccxt.Exchange):
+async def update_market_cache(exchange: "ccxt.Exchange"):
     """Fetches and caches market information from the exchange."""
     global _market_cache
+    # Import ccxt only when this function is invoked to avoid heavy dependency
+    import ccxt.async_support as ccxt
     if not exchange or not exchange.markets: # Check if markets loaded
         try:
              if not exchange: raise ValueError("Exchange object is None")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -94,7 +94,8 @@ async def test_position_manager():
     # Test initial position update (buy)
     symbol = "BTC/USDT"
     quantity = 0.1  # Buy quantity
-    price = 100.0    timestamp = datetime.utcnow().timestamp()
+    price = 100.0
+    timestamp = datetime.utcnow().timestamp()
     manager.update_position_on_fill(symbol, quantity, price, timestamp)
     position = manager.get_position(symbol)
     assert position.symbol == "BTC/USDT"


### PR DESCRIPTION
## Summary
- defer heavy `ccxt` import in `trading_utils`
- run the test suite

## Testing
- `PYTHONPATH=venv/Lib/site-packages python3 -m pytest -q tests`