### PR TITLE
Refactor backtest and update spelling dictionary

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2",
+  "words": [
+    "backtest",
+    "bitfinex",
+    "bitstamp",
+    "poloniex",
+    "sortino",
+    "calmar",
+    "tablefmt"
+  ]
+}

--- a/backtest.py
+++ b/backtest.py
@@ -42,7 +42,6 @@ def load_config() -> Dict[str, Any]:
             "min_profit_percent",
             "trade_amount",
             "max_trade_amount",
-            "trade_currency",
             "initial_balance",
         ]
         for key in required_keys:
@@ -62,8 +61,6 @@ symbol = config['symbol']
 min_profit_percent = config['min_profit_percent']
 trade_amount = config['trade_amount']
 max_trade_amount = config['max_trade_amount']
-trade_currency = config['trade_currency']
-initial_balance = config['initial_balance']
 
 # Map symbols per exchange (if needed)
 exchange_symbol_map = {
@@ -350,7 +347,7 @@ def main_backtest() -> None:
         return
 
     df_merged = synchronize_data(data)
-    initial_balance = config['initial_balance']
+    initial_balance = config["initial_balance"]
 
     # Run backtest
     balances, trade_log = backtest(
@@ -369,7 +366,6 @@ def main_backtest() -> None:
     time_diff = end_time - start_time
 
     total_profit = trade_log_df['profit'].sum()
-    initial_balance = 1000000  # Assuming this is set elsewhere in your code
 
     summary_data = [
         ["Total Profit", f"{Fore.GREEN}${total_profit:.2f}{Style.RESET_ALL}"],


### PR DESCRIPTION
## Summary
- clean up unused config variables
- set initial balance locally in `main_backtest`
- add cSpell dictionary with domain terms

## Testing
- `mypy backtest.py`
- `ruff check backtest.py`
- `flake8 backtest.py` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*