### PR TITLE
Improve docs and add module docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 .venv
 venv/
 ENV/
+secrets.yaml
 
 # IDE
 .idea/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # HydroBot v2
 
-HydroBot is a research project for exploring automated trading strategies. It is distributed under the MIT license and provided for educational purposes only. Use it at your own risk.
+[![Build Status](https://github.com/user/repo/actions/workflows/test.yml/badge.svg)](https://github.com/user/repo/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/user/repo/branch/main/graph/badge.svg?token=TOKEN)](https://codecov.io/gh/user/repo)
+
+HydroBot is a research project for exploring automated trading strategies. It is
+distributed under the MIT license and provided for educational purposes only.
+Use it at your own risk.
+
+The bot focuses on a simple scalping strategy with tight risk controls. It aims
+to capture small price movements while capping drawdowns through strict stop
+loss and position sizing rules.
 
 ## Features
 * Modular architecture with strategies, trading utilities and data ingestion modules.
@@ -26,10 +35,32 @@ Build and run all services with:
 docker-compose up --build
 ```
 This starts HydroBot, Redis and PostgreSQL containers.
+The compose file mounts `./logs` and `./data` as volumes so logs and market
+data persist across runs.
 
 For running tests in Docker:
 ```bash
 docker-compose -f docker-compose.tests.yml up --build
+```
+
+### Example Configuration
+Sample configuration files are provided as `sample_config.yaml` and
+`sample_secrets.yaml`. Copy them to `config.yaml` and `secrets.yaml` and fill in
+your values. Secrets such as API keys can also be supplied via environment
+variables (`EXCHANGE_API_KEY`, `EXCHANGE_API_SECRET`).
+
+```yaml
+exchange:
+  name: binanceus
+  is_sandbox: true
+trading:
+  symbols: ["BTC/USDT"]
+  default_trade_amount_usd: 15.0
+```
+
+### Usage Example
+```bash
+python main.py --config config.yaml
 ```
 
 ### Windows Setup

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ pylint>=2.17.0
 black>=23.1.0
 flake8>=6.0.0
 pydantic>=1.10,<2
+isort>=5.13.0

--- a/hydrobot/config/__init__.py
+++ b/hydrobot/config/__init__.py
@@ -1,5 +1,2 @@
-# hydrobot/config/__init__.py
-# This file can be empty.
-# It marks the 'config' directory as a Python package,
-# but we don't need any specific initialization code here for now.
+"""Configuration models and helpers for HydroBot."""
 

--- a/hydrobot/config/settings.py
+++ b/hydrobot/config/settings.py
@@ -1,6 +1,4 @@
-# hydrobot/config/settings.py
-# (Keep all the Pydantic models defined above as they were)
-# ... (PathSettings, ExchangeAPISettings, etc. - NO CHANGES HERE) ...
+"""Pydantic settings and configuration loading utilities."""
 
 import os
 from pydantic import BaseModel, Field, SecretStr, validator

--- a/hydrobot/data_ingestion/client_binance.py
+++ b/hydrobot/data_ingestion/client_binance.py
@@ -1,6 +1,6 @@
-# /data_collection/binance_client.py -> hydrobot/data/client_binance.py
+"""Binance client wrapper for fetching market data."""
 
-import logging # Keep standard logging import for now, get_logger will wrap it
+import logging  # Keep standard logging import for now, get_logger will wrap it
 import pandas as pd
 from binance.client import Client
 from binance.exceptions import BinanceAPIException, BinanceRequestException

--- a/hydrobot/data_ingestion/client_cryptonews.py
+++ b/hydrobot/data_ingestion/client_cryptonews.py
@@ -1,6 +1,6 @@
-# /data_collection/cryptonews_client.py -> hydrobot/data/client_cryptonews.py
+"""CryptoNews API client wrapper for news retrieval."""
 
-import logging # Keep standard logging import
+import logging  # Keep standard logging import
 import requests
 import datetime
 import pytz # For timezone handling

--- a/hydrobot/data_ingestion/client_reddit.py
+++ b/hydrobot/data_ingestion/client_reddit.py
@@ -1,4 +1,4 @@
-# /data_collection/reddit_client.py -> hydrobot/data/client_reddit.py
+"""Reddit client wrapper for subreddit news ingestion."""
 
 import praw
 import datetime

--- a/hydrobot/data_ingestion/client_twitter.py
+++ b/hydrobot/data_ingestion/client_twitter.py
@@ -1,4 +1,4 @@
-# /hydrobot/data/client_twitter.py
+"""Twitter client wrapper for tweet ingestion."""
 
 import tweepy
 import datetime

--- a/hydrobot/features/feature_generator.py
+++ b/hydrobot/features/feature_generator.py
@@ -1,4 +1,4 @@
-# /feature_engineering/feature_generator.py
+"""Feature engineering utilities for model training."""
 
 import logging
 import pandas as pd

--- a/hydrobot/models/predictor.py
+++ b/hydrobot/models/predictor.py
@@ -1,4 +1,4 @@
-# /modeling/predictor.py
+"""Core ML prediction utilities."""
 
 import logging
 import pandas as pd

--- a/hydrobot/strategies/base_strategy.py
+++ b/hydrobot/strategies/base_strategy.py
@@ -1,4 +1,4 @@
-# hydrobot/strategies/base_strategy.py
+"""Abstract base classes for trading strategies."""
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field

--- a/hydrobot/strategies/impl_scalping.py
+++ b/hydrobot/strategies/impl_scalping.py
@@ -1,4 +1,4 @@
-# hydrobot/strategies/impl_scalping.py
+"""Simple scalping strategy implementation."""
 
 from typing import Dict, Any, Optional, List, Tuple
 import time

--- a/hydrobot/strategies/impl_vwap.py
+++ b/hydrobot/strategies/impl_vwap.py
@@ -1,4 +1,3 @@
-# hydrobot/strategies/impl_vwap.py
 """VWAP based trading strategy."""
 
 from collections import deque

--- a/hydrobot/strategies/strategy_manager.py
+++ b/hydrobot/strategies/strategy_manager.py
@@ -1,4 +1,4 @@
-# hydrobot/strategies/strategy_manager.py
+"""Strategy discovery and lifecycle management."""
 
 import importlib
 import pkgutil

--- a/hydrobot/trader.py
+++ b/hydrobot/trader.py
@@ -1,4 +1,4 @@
-# hydrobot/trader.py
+"""Main trading loop orchestration logic."""
 
 import asyncio
 import time

--- a/hydrobot/trading/order_executor.py
+++ b/hydrobot/trading/order_executor.py
@@ -1,6 +1,6 @@
-# hydrobot/trading/order_executor.py
+"""Abstraction for placing and managing orders on an exchange."""
 
-import ccxt.async_support as ccxt # Use the async version of ccxt
+import ccxt.async_support as ccxt  # Use the async version of ccxt
 import asyncio
 import time
 import math

--- a/hydrobot/trading/position_manager.py
+++ b/hydrobot/trading/position_manager.py
@@ -1,4 +1,4 @@
-# hydrobot/trading/position_manager.py
+"""Tracks open positions and portfolio state."""
 
 import json
 import time

--- a/hydrobot/trading/risk_controller.py
+++ b/hydrobot/trading/risk_controller.py
@@ -1,4 +1,4 @@
-# hydrobot/trading/risk_controller.py
+"""Risk management helpers for validating trade signals."""
 
 from typing import Optional, Dict, Tuple
 import math # For isnan/isinf

--- a/hydrobot/trading/trading_utils.py
+++ b/hydrobot/trading/trading_utils.py
@@ -1,4 +1,4 @@
-# hydrobot/trading/trading_utils.py
+"""Utility helpers for order formatting and validation."""
 
 import math
 from decimal import Decimal, ROUND_DOWN, ROUND_UP # Use Decimal for precision

--- a/hydrobot/utils/logger_setup.py
+++ b/hydrobot/utils/logger_setup.py
@@ -1,4 +1,4 @@
-# hydrobot/utils/logger_setup.py
+"""Application-wide logging configuration utilities."""
 
 import logging
 import logging.handlers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ pytest-cov = "^4.1"
 black = "^24.1"
 mypy = "^1.8"
 flake8 = "^6.1"
+isort = "^5.13"
 
 [[tool.poetry.source]]
 name = "pypi"
@@ -51,6 +52,10 @@ build-backend = "poetry.core.masonry.api"
 line-length = 88
 target-version = ['py39']
 include = '\.pyi?$'
+
+[tool.isort]
+profile = "black"
+line_length = 88
 
 [tool.mypy]
 python_version = "3.9"

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -1,0 +1,21 @@
+app_name: "HydroBot"
+environment: "development"
+log_level: "INFO"
+
+exchange:
+  name: "binanceus"
+  is_sandbox: true
+
+trading:
+  symbols: ["BTC/USDT"]
+  default_order_type: "limit"
+  default_trade_amount_usd: 15.0
+
+risk:
+  max_drawdown_pct: 0.1
+  max_risk_per_trade_pct: 0.01
+
+redis:
+  host: "localhost"
+  port: 6379
+  db: 0

--- a/sample_secrets.yaml
+++ b/sample_secrets.yaml
@@ -1,0 +1,5 @@
+exchange:
+  api_key: "CHANGE_ME"
+  api_secret: "CHANGE_ME"
+redis:
+  password: "optional"


### PR DESCRIPTION
## Summary
- document Docker volumes and example configuration
- include build and coverage badges
- add sample `config.yaml` and `secrets.yaml`
- configure isort in `pyproject.toml`
- add module-level docstrings throughout the codebase
- ignore `secrets.yaml`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*