### PR TITLE
Add formatting helper script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,9 @@ Thank you for your interest in improving HydroBot.
 
 We follow the [PEP 8](https://peps.python.org/pep-0008/) style guide and use
 `black` for formatting.
+
+Run `format_code.py` before committing to ensure formatting and linting pass:
+
+```bash
+./format_code.py
+```

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ Use the provided PowerShell script to create a virtual environment and install p
 ./setup.ps1
 ```
 
+### Code Formatting
+Run the helper script to format and lint the codebase:
+
+```bash
+./format_code.py
+```
+
+`black` and `flake8` must be installed. They are listed in
+`dev-requirements.txt`.
+
 ## Directory Structure
 ```
 hydrobot/       # core package

--- a/format_code.py
+++ b/format_code.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Apply formatting and linting across the project.
+
+This script runs ``black`` followed by ``flake8`` on the repository
+root. Run it before committing changes to ensure consistent style and
+linting.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import List
+
+
+def run_command(cmd: List[str]) -> None:
+    """Run a command and exit if it fails.
+
+    Args:
+        cmd: Command and arguments to execute.
+    """
+    print(f"Running: {' '.join(cmd)}", flush=True)
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+def main() -> None:
+    """Format the codebase and run lint checks."""
+    run_command([sys.executable, "-m", "black", "."])
+    run_command([sys.executable, "-m", "flake8", "."])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add simple `format_code.py` to run Black and Flake8
- document formatting command in README and CONTRIBUTING

## Testing
- `python format_code.py` *(fails: No module named flake8)*