### PR TITLE
[CycloneNew] Add setup script for dev tooling

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create and activate a virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip wheel
+
+# Install runtime and dev dependencies
+if [[ -f requirements.txt ]]; then
+  pip install -r requirements.txt
+fi
+if [[ -f dev-requirements.txt ]]; then
+  pip install -r dev-requirements.txt
+fi
+
+# Install required dev tools for linting and testing
+pip install --upgrade flake8 pylint pytest black


### PR DESCRIPTION
## Summary
- create `setup.sh` to install runtime and dev dependencies
- include dev tools like `flake8`, `pylint`, `pytest`, and `black`

## Testing
- `black --check .` *(fails: would reformat 57 files)*
- `flake8 .` *(fails: command not found)*
- `pylint --version` *(fails: command not found)*
- `pytest --version` *(fails: command not found)*